### PR TITLE
Append to CFLAG

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 ifeq ($(MODE), DEBUG)
-CFLAG = -g -fsanitize=address
+CFLAG += -g -fsanitize=address
 else 
-CFLAG = -O3 -DNDEBUG
+CFLAG += -O3 -DNDEBUG
 endif
 
 .PHONY: clean


### PR DESCRIPTION
Currently CFLAG is set like so:

`CFLAG = -g -fsanitize=address`

I would like to include the Machete library in a shared library, however it is not possible to add `-fPIC` to `CFLAG`  since it is completely overwritten in the makefile. This change fixes that.