### PR TITLE
Added includes for C++17 and GCC 11.4

### DIFF
--- a/machete/huffman.cpp
+++ b/machete/huffman.cpp
@@ -1,6 +1,7 @@
 #include "defs.h"
 #include <queue>
 #include <stack>
+#include <cstdlib>
 
 #include "BitStream/BitReader.h"
 #include "BitStream/BitWriter.h"

--- a/machete/hybrid.cpp
+++ b/machete/hybrid.cpp
@@ -1,6 +1,7 @@
 #include "defs.h"
 #include <assert.h>
 #include <vector>
+#include <cstdlib>
 
 ssize_t hybrid_data_partition(int32_t* input, ssize_t len, std::vector<int32_t> &low_redundancy_data, ssize_t &rare_cnt, int32_t &rare_sym, EncodeCodebook &codebook) {
         // ------------------- rare_extraction --------------------


### PR DESCRIPTION
I get build errors on GCC 11.4 with C++17. These includes fix it.